### PR TITLE
Update printer_CR4NT2206C10.cfg

### DIFF
--- a/firmware/Klipper/printer_CR4NT2206C10.cfg
+++ b/firmware/Klipper/printer_CR4NT2206C10.cfg
@@ -1,7 +1,10 @@
 # This file contains pin mappings for the Creality CR4NTxxC10 as the heater pins changed.
-# To use this config, during "make menuconfig" select the STM32F103
-# with a "28KiB bootloader" and serial (on USART1 PA10/PA9)
-# communication.
+# To use this config, during "make menuconfig"
+# Micro-controller Architecture (STMicroelectronics STM32)  --->
+# Processor model (STM32F401)  --->
+# Bootloader offset (64KiB bootloader)  --->
+# Communication interface (Serial (on USART1 PA10/PA9))  --->
+
 
 # Flash this firmware by copying "out/klipper.bin" to a SD card and
 # turning on the printer with the card inserted. The firmware


### PR DESCRIPTION
You have written wrong info. 

    Processor model STM32F401
    Bootloader is 64KiB

This settings can compile klipper and it will boot, with your settings it will not boot