### PR TITLE
Update printer_CR4NT2206C10.cfg for intro, typos, probe pins

### DIFF
--- a/firmware/Klipper/printer_CR4NT2206C10.cfg
+++ b/firmware/Klipper/printer_CR4NT2206C10.cfg
@@ -1,12 +1,11 @@
-# This file contains pin mappings for the Creality CR4NTxxC10 as the heater pins changed.
-# To use this config, during "make menuconfig" select the STM32F103
-# with a "28KiB bootloader" and serial (on USART1 PA10/PA9)
-# communication.
+# This file contains pin mappings for the Creality CR4NTxxC10 as the heater, and probe pins changed.
+# To use this config, get the official firmware from:
+# https://github.com/CrealityOfficial/E3-Free-runs-Silent-Motherboard/tree/main/firmware/Klipper
 
-# Flash this firmware by copying "out/klipper.bin" to a SD card and
-# turning on the printer with the card inserted. The firmware
-# filename must end in ".bin" and must not match the last filename
-# that was flashed.
+# Flash this firmware by creating a folder called STM32F4_UPDATE in root of SD card.
+# Copy firmware to the STM32F4_UPDATE folder.
+# The firmware filename must end in ".bin" and must not match the last filename that was flashed.
+# Turn off printer, insert SD card, and then turn printer on. Flashing will take 20-30 seconds.
 
 # See docs/Config_Reference.md for a description of parameters.
 
@@ -98,7 +97,7 @@ dir_pin: PB9
 enable_pin: !PC3
 rotation_distance: 40
 microsteps: 16
-endstop_pin: !PA5
+endstop_pin: PA5
 position_min: -5
 position_endstop: -5
 position_max: 200
@@ -110,7 +109,7 @@ dir_pin: PB7
 enable_pin: !PC3
 rotation_distance: 40
 microsteps: 16
-endstop_pin: !PA6
+endstop_pin: PA6
 position_min: -2
 position_endstop: -2
 position_max: 200
@@ -122,8 +121,8 @@ dir_pin: !PB5
 enable_pin: !PC3
 rotation_distance: 8
 microsteps: 16
-# endstop_pin: probe:z_virtual_endstop           #enable to use bltouch
-endstop_pin: !PA7                #disable to use bltouch
+# endstop_pin: probe:z_virtual_endstop           #enable to use bltouch as Z endstop
+endstop_pin: PA7                #disable to use bltouch as Z endstop
 position_endstop: -0.1
 position_min: -3.5
 position_max: 200
@@ -213,7 +212,7 @@ stealthchop_threshold: 0
 pin: PA0
 kick_start_time: 0.5
 
-#set heater fan runnig with temperature over 60;
+#set heater fan running with temperature over 60;
 [heater_fan my_nozzle_fan]
 pin: PC0
 max_power: 0.8
@@ -224,12 +223,12 @@ heater_temp : 60
 fan_speed : 1.0
 
 
-# Before printing the PROBE_CALIBRATE command needs to be issued
+# Before printing, the PROBE_CALIBRATE command needs to be issued
 # to run the probe calibration procedure, described at
 # docs/Probe_Calibrate.md, to find the correct z_offset.
 
 #[probe]
-#pin: PC14
+#pin: ^PB1
 #x_offset: 0.0
 #y_offset: 0.0
 #z_offset: 1.50
@@ -247,8 +246,8 @@ switch_pin: ^!PA4
 #pins: !PA15
 
 # [bltouch]
-# sensor_pin: ^PC14       #signal check port ^stand for pull up
-# control_pin: PC13       #singal control prot
+# sensor_pin: ^PB1       #signal check port (^stands for pull up)
+# control_pin: PB0       #signal control port
 # #x_offset: -31.8
 # #y_offset: -40.5
 # #z_offset: 1.50          #z off_set configuration
@@ -272,7 +271,7 @@ z_hop_speed: 5
 # fade_end: 10
 # fade_target: 0
 
-[gcode_macro G29]				#界面中增加G29指令
+[gcode_macro G29]				#Add G29 command (auto bed mesh) to the interface
 gcode:
   G28
   bed_mesh_calibrate
@@ -287,4 +286,3 @@ max_velocity: 500
 max_accel: 3000
 max_z_velocity: 5
 max_z_accel: 100
-


### PR DESCRIPTION
Intro: don't compile firmware, just download it from Creality. Probe and BL Touch pins updated.
Various typos fixed.